### PR TITLE
Move Composer requirements to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "autoload": {
         "psr-0": { "Omnipay\\Tests\\" : "src/" }
     },
-    "require": {
+    "require-dev": {
         "guzzle/plugin-mock": "~3.1",
         "mockery/mockery": "~0.8",
         "phpunit/phpunit": "~3.7.0",


### PR DESCRIPTION
With these in the require section, it stops any repo that uses these base tests from using a higher version of PHPUnit.
