### PR TITLE
Check if gateway supports purchase before testing parameters

### DIFF
--- a/src/Omnipay/Tests/GatewayTestCase.php
+++ b/src/Omnipay/Tests/GatewayTestCase.php
@@ -235,16 +235,18 @@ abstract class GatewayTestCase extends TestCase
 
     public function testPurchaseParameters()
     {
-        foreach ($this->gateway->getDefaultParameters() as $key => $default) {
-            // set property on gateway
-            $getter = 'get'.ucfirst($key);
-            $setter = 'set'.ucfirst($key);
-            $value = uniqid();
-            $this->gateway->$setter($value);
+        if ($this->gateway->supportsPurchase()) {
+            foreach ($this->gateway->getDefaultParameters() as $key => $default) {
+                // set property on gateway
+                $getter = 'get'.ucfirst($key);
+                $setter = 'set'.ucfirst($key);
+                $value = uniqid();
+                $this->gateway->$setter($value);
 
-            // request should have matching property, with correct value
-            $request = $this->gateway->purchase();
-            $this->assertSame($value, $request->$getter());
+                // request should have matching property, with correct value
+                $request = $this->gateway->purchase();
+                $this->assertSame($value, $request->$getter());
+            }
         }
     }
 


### PR DESCRIPTION
Hey, just noticed this check was missing.
