### PR TITLE
[3.0] Added missed required parameter for GuzzleClient.

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -165,7 +165,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     public function getHttpClient()
     {
         if (null === $this->httpClient) {
-            $this->httpClient = new GuzzleClient;
+            $this->httpClient = new GuzzleClient(new \GuzzleHttp\Client);
         }
 
         return $this->httpClient;


### PR DESCRIPTION
In the main package `thephpleague/omnipay` in the branch **3.0** tests fail, because of the missed required argument for the `GuzzleClient` class in the `League\Omnipay\Tests\TestCase::getHttpClient`.
This PR fixes the problem.