### PR TITLE
Permit higher versions of PHPunit to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "guzzle/plugin-mock": "~3.1",
         "mockery/mockery": "~0.8",
-        "phpunit/phpunit": "~3.7.0",
+        "phpunit/phpunit": "~3.7.0|~4.0",
         "squizlabs/php_codesniffer": "~1.5"
     },
     "extra": {


### PR DESCRIPTION
This increases compatibility with newer versions of php. Although omnipay is moving to 3.0, there are lots of packages that still only support 2. This will allow bugfixes to continue to be applied to omnipay drivers that are still in version 2, while working in the most recent PHP version.

(In my case, I have a bug I want to fix in omnipay/firstdata, which is only omnipay v2 compatible.)