### PR TITLE
Upgrade for PHPUnit 8/9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 composer.phar
 phpunit.xml
+.idea

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
     "name": "omnipay/tests",
     "type": "library",
     "description": "Testing components for Omnipay payment processing library",
-    "keywords": ["omnipay"],
+    "keywords": [
+        "omnipay"
+    ],
     "homepage": "https://github.com/thephpleague/omnipay-tests",
     "license": "MIT",
     "authors": [
@@ -20,13 +22,16 @@
         }
     ],
     "autoload": {
-        "psr-4": { "Omnipay\\Tests\\" : "src/" }
+        "psr-4": {
+            "Omnipay\\Tests\\": "src/"
+        }
     },
     "require": {
+        "php": "^7.2",
         "php-http/mock-client": "^1.1",
         "php-http/guzzle6-adapter": "^1.1.1|^2",
         "mockery/mockery": "^1",
-        "phpunit/phpunit": "^5.7|^6"
+        "phpunit/phpunit": "^8 || ^9"
     },
     "require-dev": {
         "omnipay/common": "^3",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.2",
         "php-http/mock-client": "^1.1",
-        "php-http/guzzle6-adapter": "^1.1.1|^2",
+        "php-http/guzzle7-adapter": "^0.1.1",
         "mockery/mockery": "^1",
         "phpunit/phpunit": "^8 || ^9"
     },

--- a/src/GatewayTestCase.php
+++ b/src/GatewayTestCase.php
@@ -15,376 +15,366 @@ abstract class GatewayTestCase extends TestCase
     /** @var AbstractGateway */
     protected $gateway;
 
-    public function testGetNameNotEmpty()
+    public function testGetNameNotEmpty(): void
     {
         $name = $this->gateway->getName();
-        $this->assertNotEmpty($name);
-        $this->assertInternalType('string', $name);
+        self::assertNotEmpty($name);
+        self::assertIsString($name);
     }
 
-    public function testGetShortNameNotEmpty()
+    public function testGetShortNameNotEmpty(): void
     {
         $shortName = $this->gateway->getShortName();
-        $this->assertNotEmpty($shortName);
-        $this->assertInternalType('string', $shortName);
+        self::assertNotEmpty($shortName);
+        self::assertIsString($shortName);
     }
 
-    public function testGetDefaultParametersReturnsArray()
+    public function testGetDefaultParametersReturnsArray(): void
     {
         $settings = $this->gateway->getDefaultParameters();
-        $this->assertInternalType('array', $settings);
+        self::assertIsArray($settings);
     }
 
-    public function testDefaultParametersHaveMatchingMethods()
+    public function testDefaultParametersHaveMatchingMethods(): void
     {
         $settings = $this->gateway->getDefaultParameters();
         foreach ($settings as $key => $default) {
             $getter = 'get'.ucfirst($this->camelCase($key));
             $setter = 'set'.ucfirst($this->camelCase($key));
-            $value = uniqid();
+            $value = uniqid('', true);
 
-            $this->assertTrue(method_exists($this->gateway, $getter), "Gateway must implement $getter()");
-            $this->assertTrue(method_exists($this->gateway, $setter), "Gateway must implement $setter()");
+            self::assertTrue(method_exists($this->gateway, $getter), "Gateway must implement $getter()");
+            self::assertTrue(method_exists($this->gateway, $setter), "Gateway must implement $setter()");
 
             // setter must return instance
-            $this->assertSame($this->gateway, $this->gateway->$setter($value));
-            $this->assertSame($value, $this->gateway->$getter());
+            self::assertSame($this->gateway, $this->gateway->$setter($value));
+            self::assertSame($value, $this->gateway->$getter());
         }
     }
 
-    public function testTestMode()
+    public function testTestMode(): void
     {
-        $this->assertSame($this->gateway, $this->gateway->setTestMode(false));
-        $this->assertSame(false, $this->gateway->getTestMode());
+        self::assertSame($this->gateway, $this->gateway->setTestMode(false));
+        self::assertFalse($this->gateway->getTestMode());
 
-        $this->assertSame($this->gateway, $this->gateway->setTestMode(true));
-        $this->assertSame(true, $this->gateway->getTestMode());
+        self::assertSame($this->gateway, $this->gateway->setTestMode(true));
+        self::assertTrue($this->gateway->getTestMode());
     }
 
-    public function testCurrency()
+    public function testCurrency(): void
     {
         // currency is normalized to uppercase
-        $this->assertSame($this->gateway, $this->gateway->setCurrency('eur'));
-        $this->assertSame('EUR', $this->gateway->getCurrency());
+        self::assertSame($this->gateway, $this->gateway->setCurrency('eur'));
+        self::assertSame('EUR', $this->gateway->getCurrency());
     }
 
-    public function testSupportsAuthorize()
+    public function testSupportsAuthorize(): void
     {
         $supportsAuthorize = $this->gateway->supportsAuthorize();
-        $this->assertInternalType('boolean', $supportsAuthorize);
+        self::assertIsBool($supportsAuthorize);
 
         if ($supportsAuthorize) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->authorize());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->authorize());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'authorize'));
+            self::assertFalse(method_exists($this->gateway, 'authorize'));
         }
     }
 
-    public function testSupportsCompleteAuthorize()
+    public function testSupportsCompleteAuthorize(): void
     {
         $supportsCompleteAuthorize = $this->gateway->supportsCompleteAuthorize();
-        $this->assertInternalType('boolean', $supportsCompleteAuthorize);
+        self::assertIsBool($supportsCompleteAuthorize);
 
         if ($supportsCompleteAuthorize) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->completeAuthorize());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->completeAuthorize());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'completeAuthorize'));
+            self::assertFalse(method_exists($this->gateway, 'completeAuthorize'));
         }
     }
 
-    public function testSupportsCapture()
+    public function testSupportsCapture(): void
     {
         $supportsCapture = $this->gateway->supportsCapture();
-        $this->assertInternalType('boolean', $supportsCapture);
+        self::assertIsBool($supportsCapture);
 
         if ($supportsCapture) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->capture());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->capture());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'capture'));
+            self::assertFalse(method_exists($this->gateway, 'capture'));
         }
     }
 
-    public function testSupportsPurchase()
+    public function testSupportsPurchase(): void
     {
         $supportsPurchase = $this->gateway->supportsPurchase();
-        $this->assertInternalType('boolean', $supportsPurchase);
+        self::assertIsBool($supportsPurchase);
 
         if ($supportsPurchase) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->purchase());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->purchase());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'purchase'));
+            self::assertFalse(method_exists($this->gateway, 'purchase'));
         }
     }
 
-    public function testSupportsCompletePurchase()
+    public function testSupportsCompletePurchase(): void
     {
         $supportsCompletePurchase = $this->gateway->supportsCompletePurchase();
-        $this->assertInternalType('boolean', $supportsCompletePurchase);
+        self::assertIsBool($supportsCompletePurchase);
 
         if ($supportsCompletePurchase) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->completePurchase());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->completePurchase());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'completePurchase'));
+            self::assertFalse(method_exists($this->gateway, 'completePurchase'));
         }
     }
 
-    public function testSupportsRefund()
+    public function testSupportsRefund(): void
     {
         $supportsRefund = $this->gateway->supportsRefund();
-        $this->assertInternalType('boolean', $supportsRefund);
+        self::assertIsBool($supportsRefund);
 
         if ($supportsRefund) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->refund());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->refund());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'refund'));
+            self::assertFalse(method_exists($this->gateway, 'refund'));
         }
     }
 
-    public function testSupportsVoid()
+    public function testSupportsVoid(): void
     {
         $supportsVoid = $this->gateway->supportsVoid();
-        $this->assertInternalType('boolean', $supportsVoid);
+        self::assertIsBool($supportsVoid);
 
         if ($supportsVoid) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->void());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->void());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'void'));
+            self::assertFalse(method_exists($this->gateway, 'void'));
         }
     }
 
-    public function testSupportsCreateCard()
+    public function testSupportsCreateCard(): void
     {
         $supportsCreate = $this->gateway->supportsCreateCard();
-        $this->assertInternalType('boolean', $supportsCreate);
+        self::assertIsBool($supportsCreate);
 
         if ($supportsCreate) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->createCard());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->createCard());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'createCard'));
+            self::assertFalse(method_exists($this->gateway, 'createCard'));
         }
     }
 
-    public function testSupportsDeleteCard()
+    public function testSupportsDeleteCard(): void
     {
         $supportsDelete = $this->gateway->supportsDeleteCard();
-        $this->assertInternalType('boolean', $supportsDelete);
+        self::assertIsBool($supportsDelete);
 
         if ($supportsDelete) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->deleteCard());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->deleteCard());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'deleteCard'));
+            self::assertFalse(method_exists($this->gateway, 'deleteCard'));
         }
     }
 
-    public function testSupportsUpdateCard()
+    public function testSupportsUpdateCard(): void
     {
         $supportsUpdate = $this->gateway->supportsUpdateCard();
-        $this->assertInternalType('boolean', $supportsUpdate);
+        self::assertIsBool($supportsUpdate);
 
         if ($supportsUpdate) {
-            $this->assertInstanceOf(RequestInterface::class, $this->gateway->updateCard());
+            self::assertInstanceOf(RequestInterface::class, $this->gateway->updateCard());
         } else {
-            $this->assertFalse(method_exists($this->gateway, 'updateCard'));
+            self::assertFalse(method_exists($this->gateway, 'updateCard'));
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testAuthorizeParameters()
+    public function testAuthorizeParameters(): void
     {
         if ($this->gateway->supportsAuthorize()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->authorize();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testCompleteAuthorizeParameters()
+    public function testCompleteAuthorizeParameters(): void
     {
         if ($this->gateway->supportsCompleteAuthorize()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->completeAuthorize();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testCaptureParameters()
+    public function testCaptureParameters(): void
     {
         if ($this->gateway->supportsCapture()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->capture();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testPurchaseParameters()
+    public function testPurchaseParameters(): void
     {
         if ($this->gateway->supportsPurchase()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->purchase();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testCompletePurchaseParameters()
+    public function testCompletePurchaseParameters(): void
     {
         if ($this->gateway->supportsCompletePurchase()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->completePurchase();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testRefundParameters()
+    public function testRefundParameters(): void
     {
         if ($this->gateway->supportsRefund()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->refund();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testVoidParameters()
+    public function testVoidParameters(): void
     {
         if ($this->gateway->supportsVoid()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->void();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testCreateCardParameters()
+    public function testCreateCardParameters(): void
     {
         if ($this->gateway->supportsCreateCard()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->createCard();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testDeleteCardParameters()
+    public function testDeleteCardParameters(): void
     {
         if ($this->gateway->supportsDeleteCard()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->deleteCard();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testUpdateCardParameters()
+    public function testUpdateCardParameters(): void
     {
         if ($this->gateway->supportsUpdateCard()) {
             foreach ($this->gateway->getDefaultParameters() as $key => $default) {
                 // set property on gateway
                 $getter = 'get'.ucfirst($this->camelCase($key));
                 $setter = 'set'.ucfirst($this->camelCase($key));
-                $value = uniqid();
+                $value = uniqid('', true);
                 $this->gateway->$setter($value);
 
                 // request should have matching property, with correct value
                 $request = $this->gateway->updateCard();
-                $this->assertSame($value, $request->$getter());
+                self::assertSame($value, $request->$getter());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -8,10 +8,12 @@ use Omnipay\Common\Http\Client;
 use Omnipay\Common\Http\ClientInterface;
 use Omnipay\Common\Message\RequestInterface;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionObject;
 use Http\Mock\Client as MockClient;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use function GuzzleHttp\Psr7\parse_response;
 
 /**
  * Base class for all Omnipay tests
@@ -40,24 +42,23 @@ abstract class TestCase extends PHPUnitTestCase
      * @param string $str
      * @return string
      */
-    public function camelCase($str)
+    public function camelCase(string $str): string
     {
         return preg_replace_callback(
             '/_([a-z])/',
-            function ($match) {
+            static function ($match) {
                 return strtoupper($match[1]);
             },
             $str
         );
     }
 
-
     /**
      * Get all of the mocked requests
      *
-     * @return array
+     * @return PsrRequestInterface[]
      */
-    public function getMockedRequests()
+    public function getMockedRequests(): array
     {
         return $this->mockClient->getRequests();
     }
@@ -69,7 +70,7 @@ abstract class TestCase extends PHPUnitTestCase
      *
      * @return ResponseInterface
      */
-    public function getMockHttpResponse($path)
+    public function getMockHttpResponse(string $path): ResponseInterface
     {
         if ($path instanceof ResponseInterface) {
             return $path;
@@ -80,10 +81,10 @@ abstract class TestCase extends PHPUnitTestCase
 
         // if mock file doesn't exist, check parent directory
         if (!file_exists($dir.'/Mock/'.$path) && file_exists($dir.'/../Mock/'.$path)) {
-            return \GuzzleHttp\Psr7\parse_response(file_get_contents($dir.'/../Mock/'.$path));
+            return parse_response(file_get_contents($dir.'/../Mock/'.$path));
         }
 
-        return \GuzzleHttp\Psr7\parse_response(file_get_contents($dir.'/Mock/'.$path));
+        return parse_response(file_get_contents($dir.'/Mock/'.$path));
     }
 
     /**
@@ -100,7 +101,7 @@ abstract class TestCase extends PHPUnitTestCase
      *
      * @return void returns the created mock plugin
      */
-    public function setMockHttpResponse($paths)
+    public function setMockHttpResponse($paths): void
     {
         foreach ((array) $paths as $path) {
             $this->mockClient->addResponse($this->getMockHttpResponse($path));
@@ -110,15 +111,15 @@ abstract class TestCase extends PHPUnitTestCase
     /**
      * Helper method used by gateway test classes to generate a valid test credit card
      */
-    public function getValidCard()
+    public function getValidCard(): array
     {
-        return array(
+        return [
             'firstName' => 'Example',
             'lastName' => 'User',
             'number' => '4111111111111111',
-            'expiryMonth' => rand(1, 12),
-            'expiryYear' => gmdate('Y') + rand(1, 5),
-            'cvv' => rand(100, 999),
+            'expiryMonth' => mt_rand(1, 12),
+            'expiryYear' => gmdate('Y') + mt_rand(1, 5),
+            'cvv' => mt_rand(100, 999),
             'billingAddress1' => '123 Billing St',
             'billingAddress2' => 'Billsville',
             'billingCity' => 'Billstown',
@@ -133,10 +134,10 @@ abstract class TestCase extends PHPUnitTestCase
             'shippingState' => 'NY',
             'shippingCountry' => 'US',
             'shippingPhone' => '(555) 987-6543',
-        );
+        ];
     }
 
-    public function getMockRequest()
+    public function getMockRequest(): RequestInterface
     {
         if (null === $this->mockRequest) {
             $this->mockRequest = m::mock(RequestInterface::class);
@@ -145,7 +146,7 @@ abstract class TestCase extends PHPUnitTestCase
         return $this->mockRequest;
     }
 
-    public function getMockClient()
+    public function getMockClient(): MockClient
     {
         if (null === $this->mockClient) {
             $this->mockClient = new MockClient();
@@ -154,7 +155,7 @@ abstract class TestCase extends PHPUnitTestCase
         return $this->mockClient;
     }
 
-    public function getHttpClient()
+    public function getHttpClient(): ClientInterface
     {
         if (null === $this->httpClient) {
             $this->httpClient = new Client(
@@ -165,7 +166,7 @@ abstract class TestCase extends PHPUnitTestCase
         return $this->httpClient;
     }
 
-    public function getHttpRequest()
+    public function getHttpRequest(): HttpRequest
     {
         if (null === $this->httpRequest) {
             $this->httpRequest = new HttpRequest;


### PR DESCRIPTION
This PR will upgrade the package to support PHPUnit `^8.0 || ^9.0`.

Note that this change is not backwards compatible, because lower versions of PHPUnit are no longer supported. Reason being that `assertInternalType` has been deprecated/removed and replaced by specific assertions like `assertIsString`. Moreover, the minimal PHP version has been increased to `7.2`, because that is the lowest version supported by PHPUnit 8.0.